### PR TITLE
FIX: remove cadenza_lab reference

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ cadenza = "cadenza.__main__:cli"
 
 [tool.setuptools.package-dir]
 cadenza = "src"
-cadenza_lab = "cadenza_lab"
 
 [tool.setuptools]
 packages = [
@@ -56,7 +55,6 @@ packages = [
     "cadenza.stack.modalities",
     "cadenza.stack.vision",
     "cadenza.vla",
-    "cadenza_lab",
 ]
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
Pyproject.toml references a cadenza_lab package in two separate places, neither of which corresponds to anything that exists in the repository.
This breaks every fresh install from source -- pip install -e ., uv pip install -e ., and pip install -r requirements.txt